### PR TITLE
Update README for SUN JAVA 6

### DIFF
--- a/README.mkdn
+++ b/README.mkdn
@@ -36,6 +36,9 @@ Vanir developer Resources:
 [TUT] initializing the build environment
 
 	http://pastebin.com/1DD9ZfQ4
+	
+*USE THIS LINK FOR CORRECT ORACLE SUN JAVA INSTALL:
+	http://www.webupd8.org/2012/11/oracle-sun-java-6-installer-available.html
 
 [TUT] capturing logcats
 	


### PR DESCRIPTION
Should actually be added to the PasteBin file, for initalizing the build environment, but I have no access to that, hopefully developer who does have access will add this as this is PROBABLY the only known source of the correct Sun Java 6 JDK. It took me forever to find it, so now I don't have to hack the build setup files to allow a different version... this one passes.

http://www.webupd8.org/2012/11/oracle-sun-java-6-installer-available.html
